### PR TITLE
fix createUnion

### DIFF
--- a/lib/eventHorizon.js
+++ b/lib/eventHorizon.js
@@ -190,7 +190,7 @@ class EventHorizon{
 						newTesseract.remove(data.removedIds)
 				}, session)
 				newTesseract.on('destroy', () => {
-					session.off(null, null, session)
+					session.destroy()
 				})
 			})
 		}


### PR DESCRIPTION
I've changed createUnions behaviour to destroy subSessions that are created by it instead of just stopping their listeners. This way subsessions have a chance to be removed from overall event horizon's sessions collection.