### PR TITLE
Refactor applyOrder to treat undefined as smallest value

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -446,39 +446,50 @@ let mergeColumns = (baseColumns, optionalColumns) => {
     return updatedColumns
 }
 
+function stringComparer(a, b) { return `${a}.localeCompare(${b})` }
+function numberComparer(a, b) { return `${a} - ${b}` }
+
+function compareFieldSource(field, i, comparer, asc) {
+    const left = asc ? `a${i}` : `b${i}`
+    const right = asc ? `b${i}` : `a${i}`
+
+    return `
+        const a${i} = a.${field}, b${i} = b.${field};
+
+        if (${left} === undefined) {
+            return -1;
+        } else if (${right} === undefined) {
+            return 1;
+        }
+
+        const r${i} = ${comparer(left, right)};
+        if (r${i} !== 0) {
+            return r${i};
+        }
+    `
+}
+
 function applyOrder(sort, data, defaultObjDef) {
-    if(!sort)
+    if(!sort || !data[0]) {
         return data
-
-    if(data[0]){
-        let dataWrapperA = new defaultObjDef(data[0])
-        let dataWrapperB = new defaultObjDef()
-        let comparerSource = 'return '
-
-        sort.forEach((item, index) => {
-
-            if(index > 0)
-                comparerSource += ' || '
-
-            if(typeof dataWrapperA[item.field] === 'string'){
-                if(item.direction.toLowerCase() === 'asc')
-                    comparerSource += `a.${item.field}.localeCompare(b.${item.field})`
-                else
-                    comparerSource += `b.${item.field}.localeCompare(a.${item.field})`
-            }
-            else{
-                if(item.direction.toLowerCase() === 'asc')
-                    comparerSource += `a.${item.field} - b.${item.field}`
-                else
-                    comparerSource += `b.${item.field} - a.${item.field}`
-            }
-        })
-        
-        var comparer = new Function('a', 'b', comparerSource)
-        return data.sort( (a, b) => comparer(dataWrapperA.setData(a), dataWrapperB.setData(b)))
     }
-    else 
-        return data
+
+    let dataWrapperA = new defaultObjDef(data[0])
+    let dataWrapperB = new defaultObjDef()
+    let comparerSource = ''
+
+    sort.forEach((item, index) => {
+        comparerSource += compareFieldSource(
+            item.field,
+            index,
+            // TODO: try configuration over checking possibly undefined value
+            typeof dataWrapperA[item.field] === 'string' ? stringComparer : numberComparer,
+            item.direction.toLowerCase() === 'asc'
+        )
+    })
+
+    const comparer = new Function('a', 'b', `${comparerSource}; return 0;`)
+    return data.sort((a, b) => comparer(dataWrapperA.setData(a), dataWrapperB.setData(b)))
 }
 
 function smartDebounce(debouncedFn = () => {}, timeout = 100, leading = false){

--- a/tests/unit/applyOrder.js
+++ b/tests/unit/applyOrder.js
@@ -1,0 +1,161 @@
+const test = require("tape");
+const _ = require("lodash");
+
+const { applyOrder, createSessionProxyConfig } = require("../../lib/utils");
+
+const objectDef = createSessionProxyConfig(() => undefined, [
+  { name: "maybeNumber" },
+  { name: "maybeString" },
+  { name: "partitionByZeroish", expression: "maybeNumber > 0 ? 1 : 0" }
+]);
+
+const data = [
+  { maybeNumber: -5, maybeString: "👻" },
+  { maybeNumber: 10.5, maybeString: "foo" },
+  { maybeNumber: 10, maybeString: "foo" },
+  { maybeNumber: 10, maybeString: "bar2" },
+  { maybeNumber: 10, maybeString: undefined },
+  { maybeNumber: 10, maybeString: "" },
+  { maybeNumber: undefined, maybeString: "bar" },
+  { maybeNumber: 0, maybeString: "123" },
+  { maybeNumber: 30, maybeString: "" }
+];
+
+test("applyOrder without sort", t => {
+  const sorted = applyOrder(null, data, objectDef);
+
+  t.strictEqual(sorted, data);
+  t.end();
+});
+
+test("applyOrder with empty data", t => {
+  const empty = [];
+  const sorted = applyOrder(null, empty, objectDef);
+
+  t.strictEqual(sorted, empty);
+  t.end();
+});
+
+test("applyOrder sorting using expression", t => {
+  const sorted = applyOrder(
+    [
+      { field: "partitionByZeroish", direction: "asc" },
+      { field: "maybeString", direction: "asc" }
+    ],
+    data,
+    objectDef
+  );
+
+  t.deepEqual(sorted, [
+    { maybeNumber: -5, maybeString: "👻" },
+    { maybeNumber: 0, maybeString: "123" },
+    { maybeNumber: undefined, maybeString: "bar" },
+    // 0 or 1 partition split for the first filter
+    // (groupped records are equivalent for first filter)
+    { maybeNumber: 10, maybeString: undefined },
+    { maybeNumber: 10, maybeString: "" },
+    { maybeNumber: 30, maybeString: "" },
+    { maybeNumber: 10, maybeString: "bar2" },
+    { maybeNumber: 10.5, maybeString: "foo" },
+    { maybeNumber: 10, maybeString: "foo" }
+  ]);
+  t.end();
+});
+
+testSorting(
+  data,
+  [{ field: "maybeNumber", direction: "asc" }],
+  [[undefined], [-5],[0], [10], [10], [10], [10], [10.5], [30]]
+);
+
+testSorting(
+  data,
+  [{ field: "maybeNumber", direction: "desc" }],
+  [[30], [10.5], [10], [10], [10], [10], [0], [-5], [undefined]]
+);
+
+testSorting(
+  data,
+  [{ field: "maybeString", direction: "asc" }],
+  [
+    [undefined],
+    [""],
+    [""],
+    ["👻"],
+    ["123"],
+    ["bar"],
+    ["bar2"],
+    ["foo"],
+    ["foo"]
+  ]
+);
+
+testSorting(
+  data,
+  [{ field: "maybeString", direction: "desc" }],
+  [
+    ["foo"],
+    ["foo"],
+    ["bar2"],
+    ["bar"],
+    ["123"],
+    ["👻"],
+    [""],
+    [""],
+    [undefined]
+  ]
+);
+
+testSorting(
+  data,
+  [
+    { field: "maybeNumber", direction: "desc" },
+    { field: "maybeString", direction: "asc" }
+  ],
+  [
+    [30, ""],
+    [10.5, "foo"],
+    [10, undefined],
+    [10, ""],
+    [10, "bar2"],
+    [10, "foo"],
+    [0, "123"],
+    [-5, "👻"],
+    [undefined, "bar"]
+  ]
+);
+
+testSorting(
+  data,
+  [
+    { field: "maybeNumber", direction: "desc" },
+    { field: "maybeString", direction: "desc" }
+  ],
+  [
+    [30, ""],
+    [10.5, "foo"],
+    [10, "foo"],
+    [10, "bar2"],
+    [10, ""],
+    [10, undefined],
+    [0, "123"],
+    [-5, "👻"],
+    [undefined, "bar"]
+  ]
+);
+
+function testSorting(data, sorting, expected) {
+  const options = sorting
+    .map(({ field, direction }) => `${field} ${direction}`)
+    .join(", ");
+
+  test(`applyOrder ${options}`, t => {
+    const sorted = applyOrder(sorting, data.slice(), objectDef);
+
+    t.deepEqual(
+      sorted.map(r => sorting.map(({ field }) => r[field])),
+      expected
+    );
+    t.end();
+  });
+}

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -1,3 +1,4 @@
+require('./applyOrder')
 require('./tesseract')
 require('./group')
 require('./eventHorizon')


### PR DESCRIPTION
Fixes issue for empty string relation value throwing error.